### PR TITLE
fix: allow patients to view their own caregiver list for messaging

### DIFF
--- a/backend/core/src/main/java/com/careconnect/controller/CaregiverPatientLinkController.java
+++ b/backend/core/src/main/java/com/careconnect/controller/CaregiverPatientLinkController.java
@@ -142,8 +142,7 @@ public class CaregiverPatientLinkController {
     }
 
     // 7. Get all caregivers linked to a patient
-    @RequirePermission(Permission.VIEW_ASSIGNED_PATIENTS)
-
+    @RequirePermission(Permission.VIEW_MESSAGES)
     @GetMapping("/patients/{patientId}/caregivers")
     public ResponseEntity<List<CaregiverPatientLinkResponse>> getCaregiversByPatient(@PathVariable Long patientId) {
         User currentUser = getCurrentUser();


### PR DESCRIPTION
## Summary
- Changed `@RequirePermission` on `GET /patients/{patientId}/caregivers` from `VIEW_ASSIGNED_PATIENTS` (caregiver-only) to `VIEW_MESSAGES` (patient + caregiver)
- The method body already performs its own `isSelfPatient` / `isLinkedCaregiver` authorization check, so security is unchanged
- Fixes **"Messaging is disabled"** shown to patients who could not reach the caregivers endpoint

## Root Cause
This 1-line permission mismatch was caught after PR #235 was merged. The endpoint's internal auth guard was correct but the outer `@RequirePermission` gate blocked patients before they could reach it.

## Test Plan
- [ ] Log in as a **Patient** → open Messages → confirm caregiver list loads (no "Messaging is disabled" error)
- [ ] Log in as a **Caregiver** → confirm caregiver list still accessible as before
- [ ] Confirm no other endpoints on `CaregiverPatientLinkController` are affected