### PR TITLE
fix(team_a): restore websocket mode=local for dev environment

### DIFF
--- a/backend/core/src/main/resources/application-dev.properties
+++ b/backend/core/src/main/resources/application-dev.properties
@@ -183,6 +183,7 @@ management.endpoints.web.exposure.include=health,info,metrics
 # If AWS_WEBSOCKET_API_ENDPOINT env var is set, AwsWebSocketService loads and uses AWS
 # Otherwise, WebSocketConfig loads and uses local Spring WebSocket
 careconnect.websocket.enabled=true
+careconnect.websocket.mode=local
 careconnect.websocket.endpoint=/ws/careconnect
 careconnect.websocket.allowed-origins=http://localhost:*,https://*.careconnect.com
 careconnect.websocket.connection-ttl-minutes=30


### PR DESCRIPTION
careconnect.websocket.mode=local was dropped in abfec5c9 which caused WebSocketConfig to default to 'aws' mode and never register any handlers, breaking all WebSocket endpoints (/ws/calls-ws, /ws/chat, /ws/notifications).