### PR TITLE
fix: clean up Android manifest, rename package, free tier bypasses payment

### DIFF
--- a/frontend/android/app/build.gradle.kts
+++ b/frontend/android/app/build.gradle.kts
@@ -37,12 +37,12 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.example.care_connect_app"
+        applicationId = "edu.umgc.careconnect"
         minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-        manifestPlaceholders["appAuthRedirectScheme"] = "com.example.care_connect_app"
+        manifestPlaceholders["appAuthRedirectScheme"] = "edu.umgc.careconnect"
     }
 
     buildTypes {

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -1,31 +1,35 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" >
-    <uses-permission android:name="android.permission.INTERNET"/>
-<uses-permission android:name="android.permission.RECORD_AUDIO" />
-<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <!-- Camera -->
-    <uses-permission android:name="android.permission.CAMERA"/>  
-    <!--Location-->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-<!-- FOR LLM -->
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-<!-- Notifications -->
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-<!-- Needed for fullScreenIntent:true to work as a full-screen alert -->
-<uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/>
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- Reading images, handle SDK 33+ and pre-33 -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- Network -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Audio -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+
+    <!-- Storage -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
+    <!-- Camera -->
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <!-- Location -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <!-- Notifications -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+
     <application
-        android:label="care_connect_app"
+        android:label="Care Connect"
         android:name="${applicationName}"
         android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher"
@@ -39,34 +43,24 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- Specifies an Android theme to apply to this Activity as soon as
-                 the Android process has started. This theme is visible to the user
-                 while the Flutter UI initializes. After that, this theme continues
-                 to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <!-- Don't delete the meta-data below.
-             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
-    <!-- Required to query activities that can process text, see:
-         https://developer.android.com/training/package-visibility and
-         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
 
-         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
     <queries>
         <intent>
-            <action android:name="android.intent.action.PROCESS_TEXT"/>
-            <data android:mimeType="text/plain"/>
+            <action android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
         </intent>
     </queries>
+
 </manifest>

--- a/frontend/lib/features/payments/presentation/pages/subscription_tier_selection_page.dart
+++ b/frontend/lib/features/payments/presentation/pages/subscription_tier_selection_page.dart
@@ -204,8 +204,13 @@ class _SubscriptionTierSelectionPageState
   void _continueToPayment() {
     if (_selectedTier == null) return;
 
+    // Free tier bypasses payment entirely
+    if (_selectedTier == 'free') {
+      context.go('/home');
+      return;
+    }
+
     final tierIdMap = {
-      'free': 1,
       'standard_monthly': 2,
       'premium_monthly': 3,
     };


### PR DESCRIPTION
## Summary
Three fixes applied to the Android build in preparation for Google Play 
Console internal testing upload.

## Changes

### Package name
- Renamed application ID from `com.example.care_connect_app` to 
  `edu.umgc.careconnect`
- Updated appAuthRedirectScheme to match new package name
- `com.example` is restricted by Google Play and cannot be used for uploads

### Android manifest cleanup
- Removed duplicate declarations of INTERNET, RECORD_AUDIO, and 
  WRITE_EXTERNAL_STORAGE permissions
- Added android:maxSdkVersion="28" to WRITE_EXTERNAL_STORAGE — not needed 
  above API 28
- Updated android:label from `care_connect_app` to `Care Connect` to match 
  Google Play store listing name
- Cleaned up formatting and removed redundant comments

### Free tier payment bypass
- Free plan selection now routes directly to home screen instead of the 
  payment flow
- Free access does not require a Google Play subscription product
- Only standard_monthly and standard_monthly trigger the billing flow
- Prevents free users from being routed through purchase screens

## Google Play Console
- AAB successfully built and uploaded to internal testing track
- Subscription products created: standard_monthly ($9.99) and 
  premium_monthly ($29.99)
- Internal tester added and opt-in invitation accepted

## Notes
- PR to team_d first, then team_d to main
