### PR TITLE
Team B: Improve database encryption service documentation and observa…

### DIFF
--- a/frontend/lib/services/local_db/db_encryption_service.dart
+++ b/frontend/lib/services/local_db/db_encryption_service.dart
@@ -5,10 +5,20 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 /// Handles encryption key lifecycle for the local SQLCipher database.
 ///
-/// Keys are stored in platform secure storage and reused across app launches.
+/// Responsibilities:
+/// - Retrieve existing encryption key from secure storage
+/// - Generate and persist a new key if none exists
+/// - Provide utilities for safe key usage in SQLCipher
+/// - Support secure key deletion for reset scenarios
+///
+/// Security Notes:
+/// - Encryption keys are stored in platform secure storage
+/// - Keys are never logged or exposed
+/// - All operations avoid leaking sensitive values
 class DbEncryptionService {
   DbEncryptionService({FlutterSecureStorage? storage})
-    : _storage = storage ?? const FlutterSecureStorage(webOptions: WebOptions.defaultOptions);
+      : _storage = storage ??
+            const FlutterSecureStorage(webOptions: WebOptions.defaultOptions);
 
   static const String _encryptionKeyStorageKey = 'careconnect_db_key_v1';
   final FlutterSecureStorage _storage;
@@ -16,24 +26,52 @@ class DbEncryptionService {
   /// Returns an existing encryption key or creates and stores a new one.
   Future<String> getOrCreateEncryptionKey() async {
     final existing = await _storage.read(key: _encryptionKeyStorageKey);
+
     if (existing != null && existing.isNotEmpty) {
+      assert(() {
+        print('[DbEncryption] Existing encryption key found');
+        return true;
+      }());
       return existing;
     }
+
+    assert(() {
+      print('[DbEncryption] No key found, generating new encryption key');
+      return true;
+    }());
 
     final random = Random.secure();
     final bytes = List<int>.generate(32, (_) => random.nextInt(256));
     final generated = base64UrlEncode(bytes);
+
     await _storage.write(key: _encryptionKeyStorageKey, value: generated);
+
+    assert(() {
+      print('[DbEncryption] New encryption key generated and stored');
+      return true;
+    }());
+
     return generated;
   }
 
   /// Returns true when an encryption key has already been stored.
   Future<bool> hasEncryptionKey() async {
     final existing = await _storage.read(key: _encryptionKeyStorageKey);
-    return existing != null && existing.isNotEmpty;
+
+    final hasKey = existing != null && existing.isNotEmpty;
+
+    assert(() {
+      print('[DbEncryption] Key exists: $hasKey');
+      return true;
+    }());
+
+    return hasKey;
   }
 
   /// Escapes single quotes for safe use in PRAGMA statements.
+  ///
+  /// NOTE:
+  /// This method does not log or expose key contents.
   String escapeForPragma(String rawKey) {
     return rawKey.replaceAll("'", "''");
   }
@@ -43,6 +81,11 @@ class DbEncryptionService {
   /// Useful for factory-reset flows when the encrypted database is unreadable
   /// and needs to be recreated from scratch.
   Future<void> deleteKey() async {
+    assert(() {
+      print('[DbEncryption] Deleting stored encryption key');
+      return true;
+    }());
+
     await _storage.delete(key: _encryptionKeyStorageKey);
   }
 }


### PR DESCRIPTION
Summary of Changes

* Added documentation to DbEncryptionService to clarify responsibilities and security considerations.
* Introduced debug-only logging (using assert) to improve observability of encryption key lifecycle events during development.
* Ensured that no sensitive data (such as encryption keys) is logged or exposed.

Scope & Impact

* Change is limited to a single local database service file.
* No impact on UI, backend integration, or encryption logic.
* Logging executes only in debug mode and has no effect in production.

Purpose

* Improve code readability and maintainability.
* Provide better visibility into encryption key handling during development and debugging while maintaining security best practices.
