### PR TITLE
fix: resolve in-home profile and activity logging regressions

### DIFF
--- a/backend/core/src/main/java/com/careconnect/config/SchemaPatchRunner.java
+++ b/backend/core/src/main/java/com/careconnect/config/SchemaPatchRunner.java
@@ -51,6 +51,23 @@ public class SchemaPatchRunner implements CommandLineRunner {
             "V55c – index on evv_outbox(status)",
             "CREATE INDEX IF NOT EXISTS idx_outbox_status ON evv_outbox(status)"
         );
+        applyPatch(
+            "V62a – create risk_types table",
+            "CREATE TABLE IF NOT EXISTS risk_types (" +
+            "  id BIGSERIAL PRIMARY KEY," +
+            "  name VARCHAR(100) NOT NULL UNIQUE" +
+            ")"
+        );
+        applyPatch(
+            "V62b – seed predefined risk types",
+            "INSERT INTO risk_types (name) VALUES " +
+            "('Aspiration Pneumonia')," +
+            "('Elopement')," +
+            "('Fall with Injury')," +
+            "('Self-Harm')," +
+            "('Seizures') " +
+            "ON CONFLICT (name) DO NOTHING"
+        );
         seedDemoScheduledVisits();
     }
 

--- a/backend/core/src/main/java/com/careconnect/controller/ActivityLogController.java
+++ b/backend/core/src/main/java/com/careconnect/controller/ActivityLogController.java
@@ -87,7 +87,7 @@ public class ActivityLogController {
             throw new AppException(HttpStatus.BAD_REQUEST, "competencyScore out of range");
         }
         if (req.getSatisfactionRating() != null
-                && (req.getSatisfactionRating() < 1 || req.getSatisfactionRating() > 3)) {
+                && (req.getSatisfactionRating() < 1 || req.getSatisfactionRating() > 5)) {
             throw new AppException(HttpStatus.BAD_REQUEST, "satisfactionRating out of range");
         }
 

--- a/backend/core/src/main/java/com/careconnect/controller/ConfigController.java
+++ b/backend/core/src/main/java/com/careconnect/controller/ConfigController.java
@@ -52,6 +52,12 @@ public class ConfigController {
         List<CompetencyScaleDtos.CompetencyScaleItem> items = new ArrayList<>();
         for (int v = min; v <= max; v++) {
             String label = configService.getValue(KEY_LABEL_PREFIX + v).orElse("");
+            if (label != null) {
+                label = label.trim();
+            }
+            if (label == null || label.isEmpty()) {
+                label = defaultCompetencyLabel(v);
+            }
             labels.put(v, label);
             items.add(new CompetencyScaleDtos.CompetencyScaleItem(v, label));
         }
@@ -106,6 +112,23 @@ public class ConfigController {
             return Integer.parseInt(raw.trim());
         } catch (Exception e) {
             return def;
+        }
+    }
+
+    private static String defaultCompetencyLabel(int value) {
+        switch (value) {
+            case 1:
+                return "Total Assistance";
+            case 2:
+                return "Maximum Assistance";
+            case 3:
+                return "Moderate Assistance";
+            case 4:
+                return "Minimal Assistance";
+            case 5:
+                return "Independent";
+            default:
+                return "";
         }
     }
 }

--- a/frontend/lib/features/activities/presentation/pages/activity_log_history_screen.dart
+++ b/frontend/lib/features/activities/presentation/pages/activity_log_history_screen.dart
@@ -68,9 +68,11 @@ class _ActivityLogHistoryScreenState extends State<ActivityLogHistoryScreen> {
 
   static String _satisfactionEmoji(int? r) {
     if (r == null) return '';
-    if (r == 1) return '😞';
-    if (r == 2) return '😐';
-    if (r == 3) return '😊';
+    if (r == 1) return '😫';
+    if (r == 2) return '😕';
+    if (r == 3) return '😐';
+    if (r == 4) return '🙂';
+    if (r == 5) return '😄';
     return '';
   }
 
@@ -87,7 +89,7 @@ class _ActivityLogHistoryScreenState extends State<ActivityLogHistoryScreen> {
             Text(
               widget.clientName,
               style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.8),
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
               ),
             ),
           ],

--- a/frontend/lib/features/activities/presentation/pages/client_activities_screen.dart
+++ b/frontend/lib/features/activities/presentation/pages/client_activities_screen.dart
@@ -276,7 +276,7 @@ class _LogActivitySheetState extends State<LogActivitySheet> {
   bool _loadingScale = true;
   String? _scaleError;
   int? _selectedScore;
-  int? _satisfaction; // 1 = 😞, 2 = 😐, 3 = 😊
+  int? _satisfaction; // 1..5 Likert emoji scale
   final _notesController = TextEditingController();
   bool _submitting = false;
 
@@ -465,24 +465,38 @@ class _LogActivitySheetState extends State<LogActivitySheet> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   _SatisfactionButton(
-                    emoji: '😞',
+                    emoji: '😫',
                     value: 1,
                     selected: _satisfaction == 1,
                     onTap: () => setState(() => _satisfaction = 1),
                   ),
-                  const SizedBox(width: 16),
+                  const SizedBox(width: 10),
                   _SatisfactionButton(
-                    emoji: '😐',
+                    emoji: '😕',
                     value: 2,
                     selected: _satisfaction == 2,
                     onTap: () => setState(() => _satisfaction = 2),
                   ),
-                  const SizedBox(width: 16),
+                  const SizedBox(width: 10),
                   _SatisfactionButton(
-                    emoji: '😊',
+                    emoji: '😐',
                     value: 3,
                     selected: _satisfaction == 3,
                     onTap: () => setState(() => _satisfaction = 3),
+                  ),
+                  const SizedBox(width: 10),
+                  _SatisfactionButton(
+                    emoji: '🙂',
+                    value: 4,
+                    selected: _satisfaction == 4,
+                    onTap: () => setState(() => _satisfaction = 4),
+                  ),
+                  const SizedBox(width: 10),
+                  _SatisfactionButton(
+                    emoji: '😄',
+                    value: 5,
+                    selected: _satisfaction == 5,
+                    onTap: () => setState(() => _satisfaction = 5),
                   ),
                 ],
               ),

--- a/frontend/lib/services/api_service.dart
+++ b/frontend/lib/services/api_service.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:convert';
+import 'dart:convert';
 import 'dart:io';
 // import 'dart:typed_data';
 
@@ -1521,7 +1521,7 @@ class ApiService {
     final headers = await AuthTokenManager.getAuthHeaders();
     return await _httpClient
         .put(
-          Uri.parse('${ApiConstants.patients}/$patientId'),
+          Uri.parse('${ApiConstants.patients}/$patientId/profile'),
           headers: headers,
           body: jsonEncode(updatedProfile),
         )


### PR DESCRIPTION
Route caregiver personalization updates to the patient profile endpoint, restore risk-type defaults after local resets, and improve ADL/IADL logging UX with a 5-point satisfaction scale and default competency labels.

## Summary
- Fix caregiver patient personalization save path to use patient profile endpoint.
- Restore missing Known Risks options by seeding default risk types on startup.
- Update ADL/IADL client satisfaction to a 5-point Likert emoji scale and align backend validation.
- Add default competency labels when config labels are blank.
## Validation
- Verified caregiver profile personalization save no longer returns 500.
- Verified Known Risks options reappear after backend restart.
- Verified ADL/IADL log modal shows 5 satisfaction faces and saves ratings 1-5.
