### PR TITLE
Fix/call analytics schema patches

### DIFF
--- a/backend/core/src/main/java/com/careconnect/config/SchemaPatchRunner.java
+++ b/backend/core/src/main/java/com/careconnect/config/SchemaPatchRunner.java
@@ -68,6 +68,39 @@ public class SchemaPatchRunner implements CommandLineRunner {
             "('Seizures') " +
             "ON CONFLICT (name) DO NOTHING"
         );
+        applyPatch(
+            "V70a – rename stripe_customer_id → payment_customer_id on users",
+            "ALTER TABLE users RENAME COLUMN stripe_customer_id TO payment_customer_id"
+        );
+        applyPatch(
+            "V70b – rename stripe_customer_id → payment_customer_id on subscriptions",
+            "ALTER TABLE subscriptions RENAME COLUMN stripe_customer_id TO payment_customer_id"
+        );
+        applyPatch(
+            "V71 – rename stripe_subscription_id → payment_subscription_id on subscriptions",
+            "ALTER TABLE subscriptions RENAME COLUMN stripe_subscription_id TO payment_subscription_id"
+        );
+        applyPatch(
+            "V72 – drop NOT NULL on payment_subscription_id",
+            "ALTER TABLE subscriptions ALTER COLUMN payment_subscription_id DROP NOT NULL"
+        );
+        applyPatch(
+            "V72b – drop NOT NULL on stripe_subscription_id if column still exists",
+            "ALTER TABLE subscriptions ALTER COLUMN stripe_subscription_id DROP NOT NULL"
+        );
+        applyPatch(
+            "V73 – add transcription_status to call_recordings",
+            "ALTER TABLE call_recordings ADD COLUMN IF NOT EXISTS transcription_status VARCHAR(20) NULL"
+        );
+        applyPatch(
+            "V74 – update mock user addresses to Falls Church, VA",
+            "UPDATE patient SET city = 'Falls Church', state = 'VA', zip = '22046' " +
+            "WHERE user_id = (SELECT id FROM users WHERE email = 'patient@careconnect.com') " +
+            "AND city IN ('Springfield', 'Chicago');" +
+            "UPDATE caregiver SET city = 'Falls Church', state = 'VA', zip = '22046' " +
+            "WHERE user_id IN (SELECT id FROM users WHERE email IN ('caregiver@careconnect.com', 'sarah.mitchell@careconnect.com')) " +
+            "AND city IN ('Springfield', 'Chicago')"
+        );
         seedDemoScheduledVisits();
     }
 

--- a/backend/core/src/main/java/com/careconnect/service/PostCallTranscriptionService.java
+++ b/backend/core/src/main/java/com/careconnect/service/PostCallTranscriptionService.java
@@ -9,8 +9,10 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,6 +84,9 @@ public class PostCallTranscriptionService {
   private CallTranscriptService callTranscriptService;
 
   @Autowired
+  private CallTelemetryService callTelemetryService;
+
+  @Autowired
   private CallRecordingRepository recordingRepository;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -129,8 +134,8 @@ public class PostCallTranscriptionService {
         return;
       }
 
-      // Build speaker label map (spk_0/spk_1 → role names) from call JOIN events
-      final Map<String, String> speakerMap = buildSpeakerRoleMap();
+      // Build speaker label map using participant count from telemetry JOIN events
+      final Map<String, String> speakerMap = buildSpeakerRoleMap(callId);
       final List<TranscriptSegmentInput> segments =
           downloadAndParse(rec.getS3Bucket(), outputKey, rec.getStartedAt(), speakerMap);
       if (!segments.isEmpty()) {
@@ -334,21 +339,32 @@ public class PostCallTranscriptionService {
   }
 
   /**
-   * Returns a fixed speaker-label map from Transcribe's generic labels to
-   * "Speaker 1" / "Speaker 2".
+   * Builds a speaker-label map sized to the number of unique participants who joined the call.
+   * spk_0 → "Speaker 1", spk_1 → "Speaker 2", ..., spk_(N-1) → "Speaker N".
+   * Any Transcribe label beyond the known participant count is left unmapped so it falls
+   * through to "Unidentified Speaker" — indicating AWS Transcribe detected more voices
+   * than there were participants (e.g. background noise, echo).
    */
-  private Map<String, String> buildSpeakerRoleMap() {
+  private Map<String, String> buildSpeakerRoleMap(final String callId) {
+    final Set<Long> participantIds = new HashSet<>();
+    try {
+      callTelemetryService.getTelemetryForCall(callId).stream()
+          .filter(e -> "CALL_JOIN".equalsIgnoreCase(e.getEventType()) && e.getActorUserId() != null)
+          .forEach(e -> participantIds.add(e.getActorUserId()));
+    } catch (Exception e) {
+      log.warn("Could not resolve participant count for call {} — defaulting to 2 speakers: {}", callId, e.getMessage());
+    }
+    final int participantCount = Math.max(participantIds.size(), 2);
     final Map<String, String> map = new HashMap<>();
-    map.put("spk_0", "Speaker 1");
-    map.put("spk_1", "Speaker 2");
+    for (int i = 0; i < participantCount; i++) {
+      map.put("spk_" + i, "Speaker " + (i + 1));
+    }
     return map;
   }
 
   /**
-   * Converts a raw Transcribe speaker label to a human-readable label.
-   * {@code spk_0} and {@code spk_1} are mapped by the caller via {@code speakerMap}.
-   * Any additional label (e.g. {@code spk_2+}) means Transcribe could not confidently
-   * assign the segment to either known participant, so it is labelled "Unidentified Speaker".
+   * Fallback label when a Transcribe speaker tag has no entry in the speaker map —
+   * meaning AWS detected more distinct voices than known participants on the call.
    */
   private static String toSpeakerLabel() {
     return "Unidentified Speaker";

--- a/backend/core/src/main/resources/db/migration/mock_data.sql
+++ b/backend/core/src/main/resources/db/migration/mock_data.sql
@@ -30,14 +30,14 @@ INSERT INTO users (email, email_verified, password, password_hash, role, status,
 -- ============================================
 
 INSERT INTO patient (user_id, first_name, last_name, dob, email, phone, line1, line2, city, state, zip, gender) VALUES
-((SELECT id FROM users WHERE email = 'patient@careconnect.com'), 'Mary', 'Johnson', '1958-03-15', 'patient@careconnect.com', '555-0101', '123 Maple Street', 'Apt 4B', 'Springfield', 'IL', '62701', 'FEMALE');
+((SELECT id FROM users WHERE email = 'patient@careconnect.com'), 'Mary', 'Johnson', '1958-03-15', 'patient@careconnect.com', '555-0101', '123 Maple Street', 'Apt 4B', 'Falls Chrurch', 'VA', '22046', 'FEMALE');
 
 -- ============================================
 -- 3. CAREGIVER TABLE - Use embedded Address fields (line1, line2, not address_line1/2)
 -- ============================================
 
 INSERT INTO caregiver (user_id, first_name, last_name, dob, email, phone, line1, line2, city, state, zip, gender, caregiver_type) VALUES
-((SELECT id FROM users WHERE email = 'caregiver@careconnect.com'), 'Jennifer', 'Smith', '1985-09-12', 'caregiver@careconnect.com', '555-0200', '321 Healthcare Plaza', 'Suite 200', 'Chicago', 'IL', '60607', 'FEMALE', 'RN');
+((SELECT id FROM users WHERE email = 'caregiver@careconnect.com'), 'Jennifer', 'Smith', '1985-09-12', 'caregiver@careconnect.com', '555-0200', '321 Healthcare Plaza', 'Suite 200', 'Falls Chrurch', 'VA', '22046', 'FEMALE', 'RN');
 
 INSERT INTO caregiver (user_id, first_name, last_name, dob, email, phone, line1, line2, city, state, zip, gender, caregiver_type)
 SELECT
@@ -49,9 +49,9 @@ SELECT
     '(555) 123-4567',
     '400 Medical Center Drive',
     'Suite 120',
-    'Chicago',
-    'IL',
-    '60616',
+    'Falls Chrurch',
+    'VA',
+    '22046',
     'FEMALE',
     'MD'
 WHERE NOT EXISTS (

--- a/frontend/lib/config/router/app_router.dart
+++ b/frontend/lib/config/router/app_router.dart
@@ -32,6 +32,7 @@ import '../../config/navigation/main_screen_config.dart';
 import '../../config/navigation/navigation_helper.dart';
 import '../../services/user_role_storage_service.dart';
 import 'package:care_connect_app/features/health/virtual_check_in/presentation/pages/patient_check_in_page_entry.dart';
+import 'package:care_connect_app/features/health/caregiver-patient-list/page/caregiver-patient-list.dart';
 import '../../features/welcome/presentation/pages/welcome_page.dart';
 import '../../features/auth/presentation/pages/login_page.dart';
 import '../../features/auth/presentation/pages/oauth_callback_page.dart';
@@ -880,6 +881,10 @@ final GoRouter appRouter = GoRouter(
       builder: (_, __) => const InformedDeliveryScreen(),
     ),
     // Handle routes from legacy menus
+    GoRoute(
+      path: '/tasks',
+      builder: (context, state) => const CaregiverPatientList(),
+    ),
     GoRoute(
       path: '/taskscheduling',
       redirect: (context, state) async {

--- a/frontend/lib/widgets/post_call_telemetry_summary_screen.dart
+++ b/frontend/lib/widgets/post_call_telemetry_summary_screen.dart
@@ -464,11 +464,32 @@ class _PostCallTelemetrySummaryScreenState
 
   // ── Duration ──────────────────────────────────────────────────────
 
-  DateTime? get _callStart =>
-      _callTelemetry.isEmpty ? null : _safeDate(_callTelemetry.first['occurredAt']);
+  // Anchor to CALL_JOIN / CALL_END events so pre-call and post-call telemetry
+  // (sentiment samples, summaries) don't inflate the displayed duration.
+  // Falls back to first/last event if the typed anchors are missing.
+  DateTime? get _callStart {
+    if (_callTelemetry.isEmpty) return null;
+    final joinEvent = _callTelemetry.firstWhere(
+      (e) {
+        final t = ((e['eventType'] ?? '') as String).toUpperCase();
+        return t == 'CALL_JOIN' || t == 'CALL_STARTED';
+      },
+      orElse: () => _callTelemetry.first,
+    );
+    return _safeDate(joinEvent['occurredAt']);
+  }
 
-  DateTime? get _callEnd =>
-      _callTelemetry.isEmpty ? null : _safeDate(_callTelemetry.last['occurredAt']);
+  DateTime? get _callEnd {
+    if (_callTelemetry.isEmpty) return null;
+    final endEvent = _callTelemetry.lastWhere(
+      (e) {
+        final t = ((e['eventType'] ?? '') as String).toUpperCase();
+        return t == 'CALL_END' || t == 'CALL_ENDED';
+      },
+      orElse: () => _callTelemetry.last,
+    );
+    return _safeDate(endEvent['occurredAt']);
+  }
 
   double get _callDurationMinutes {
     final start = _callStart;


### PR DESCRIPTION
## Summary

**Schema patches (V70–V73)**: Added missing DB migrations to SchemaPatchRunner so the production Aurora instance picks them up on restart — renames stripe_customer_id → payment_customer_id and stripe_subscription_id → payment_subscription_id, drops NOT NULL on payment_subscription_id, and adds transcription_status column to call_recordings. Also adds V72b to drop NOT NULL on the legacy stripe_subscription_id column if it still exists on prod, fixing a payment insert failure.

**Conference call speaker labels**: PostCallTranscriptionService now queries CALL_JOIN telemetry events to determine how many participants were on the call and dynamically maps spk_0 → Speaker 1, spk_1 → Speaker 2, spk_2 → Speaker 3, etc. Previously hardcoded to 2 speakers, causing the 3rd participant on a conference call to always show as "Unidentified Speaker."

**Call analytics duration & sentiment fix:** post_call_telemetry_summary_screen.dart now anchors _callStart / _callEnd to CALL_JOIN / CALL_END typed events instead of the first and last telemetry record. Pre- and post-call sentiment samples were inflating the displayed duration (e.g. 44:31 instead of 19:24), which also skewed all sentiment percentages and timeline positions on the analytics page.